### PR TITLE
fix: sidebar 좌측 공백 제거

### DIFF
--- a/02_youtube/index.html
+++ b/02_youtube/index.html
@@ -47,303 +47,6 @@
   </header>
     <!-- 메인 컨테이너 -->
     <main>
-      <div class="v-container">
-        <container class="video-container">
-          <!-- 비디오 카드1 -->
-          <article class="video-card">
-            <a href="#" class="video-link">
-              <div class="thumbnail"></div>
-              <div class="details">
-                <div class="avatar-container"></div>
-                <div class="meta">
-                  <div class="meta-header">
-                    <h3 class="video-title">비디오 타이틀</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="channel-name">채널명</p>
-                  <p class="video-stats">조회수 • 일자</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 비디오 카드2 -->
-          <article class="video-card">
-            <a href="#" class="video-link">
-              <div class="thumbnail"></div>
-              <div class="details">
-                <div class="avatar-container"></div>
-                <div class="meta">
-                  <div class="meta-header">
-                    <h3 class="video-title">비디오 타이틀</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="channel-name">채널명</p>
-                  <p class="video-stats">조회수 • 일자</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 비디오 카드3 -->
-          <article class="video-card">
-            <a href="#" class="video-link">
-              <div class="thumbnail"></div>
-              <div class="details">
-                <div class="avatar-container"></div>
-                <div class="meta">
-                  <div class="meta-header">
-                    <h3 class="video-title">비디오 타이틀</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="channel-name">채널명</p>
-                  <p class="video-stats">조회수 • 일자</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 비디오 카드4 -->
-          <article class="video-card">
-            <a href="#" class="video-link">
-              <div class="thumbnail"></div>
-              <div class="details">
-                <div class="avatar-container"></div>
-                <div class="meta">
-                  <div class="meta-header">
-                    <h3 class="video-title">비디오 타이틀</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="channel-name">채널명</p>
-                  <p class="video-stats">조회수 • 일자</p>
-                </div>
-              </div>
-            </a>
-          </article>
-        </container>
-        <h2 class="shorts-logo">
-          <svg
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          > <title>YouTube Shorts</title>
-            <path
-              fill="currentColor"
-              d="m18.931 9.99-1.441-.601 1.717-.913a4.48 4.48 0 0 0 1.874-6.078 4.506 4.506 0 0 0-6.09-1.874L4.792 
-            5.929a4.504 4.504 0 0 0-2.402 4.193 4.521 4.521 0 0 0 2.666 3.904c.036.012 1.442.6 1.442.6l-1.706.901a4.51 
-            4.51 0 0 0-2.369 3.967A4.528 4.528 0 0 0 6.93 24c.725 0 1.437-.174 2.08-.508l10.21-5.406a4.494 4.494 0 0 0 
-            2.39-4.192 4.525 4.525 0 0 0-2.678-3.904ZM9.597 15.19V8.824l6.007 3.184z"
-            />
-          </svg>
-          <span class="shorts-text">Shorts</span>
-        </h2>
-        <container class="shorts-container">
-          <!-- 쇼츠 카드1 -->
-          <article class="shorts-card">
-            <a href="#" class="shorts-link">
-               <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/lPF6RwWyzTw/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLDRFfR5DbA0xTuwz0ixXEZT7-tMrw" alt="피자헛 치즈 크러스트 소송">
-              <div class="shorts-details">
-                <div class="s-meta">
-                  <div class="s-meta-header">
-                    <h3 class="shorts-title">피자헛 치즈 크러스트 소송</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="video-stats">조회수 154만회</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 쇼츠 카드2 -->
-          <article class="shorts-card">
-            <a href="#" class="shorts-link">
-              <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/1asKWWsJdKA/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLCuL7O1sYf10SBPWM2omUbTG2aI9g" alt="인도 음식을 먹은 유튜버의 최후">
-              <div class="shorts-details">
-                <div class="s-meta">
-                  <div class="s-meta-header">
-                    <h3 class="shorts-title">인도 음식을 먹은 유튜버의 최후</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="video-stats">조회수 306만회</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 쇼츠 카드3 -->
-          <article class="shorts-card">
-            <a href="#" class="shorts-link">
-              <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/CzWoRmk7HiE/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLBA5uOP3SOaFtP1rhGr_TjRs108Wg" alt="중국 공포의 공중다리 #여행">
-              <div class="shorts-details">
-                <div class="s-meta">
-                  <div class="s-meta-header">
-                    <h3 class="shorts-title">중국 공포의 공중다리 #여행</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="video-stats">조회수 150만회</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 쇼츠 카드4 -->
-          <article class="shorts-card">
-            <a href="#" class="shorts-link">
-              <img class="shorts-thumbnail"src="https://i.ytimg.com/vi/-3pMaq8Vka8/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLBVil2Tlj46Jw2_-oD1FrT34RFyQw" alt="일부러 검은색이 될 때까지 쓰는 거라는데?">
-              <div class="shorts-details">
-                <div class="s-meta">
-                  <div class="s-meta-header">
-                    <h3 class="shorts-title">일부러 검은색이 될 때까지 쓰는 거라는데?</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="video-stats">조회수 165만회</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 쇼츠 카드5 -->
-          <article class="shorts-card">
-            <a href="#" class="shorts-link">
-              <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/izWBMptqL68/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLC3j2sP2PKGrcmugOUo15YXHpKbuA" alt="골절된 말을 안락사 시키는 이유">
-              <div class="shorts-details">
-                <div class="s-meta">
-                  <div class="s-meta-header">
-                    <h3 class="shorts-title">골절된 말을 안락사 시키는 이유</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="video-stats">조회수 315만회</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 쇼츠 카드6 -->
-          <article class="shorts-card">
-            <a href="#" class="shorts-link">
-              <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/akdd0ny6i8w/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLDa1AXCKtH-iYio8Uio4Kyk8qMyHQ" alt="호수에 이게 대체 왜 있을까?">
-              <div class="shorts-details">
-                <div class="s-meta">
-                  <div class="s-meta-header">
-                    <h3 class="shorts-title">호수에 이게 대체 왜 있을까?</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="video-stats">조회수 7.1만회</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 쇼츠 카드7 -->
-          <article class="shorts-card">
-            <a href="#" class="shorts-link">
-              <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/bxemLsZVlVE/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLA3A6CXlVcy_HcARMNkuWb41P8PfQ" alt="낫토와 청국장의 차이">
-              <div class="shorts-title">
-                <div class="s-meta">
-                  <div class="s-meta-header">
-                    <h3 class="shorts-title">낫토와 청국장의 차이</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="video-stats">조회수 10만회</p>
-                </div>
-              </div>
-            </a>
-          </article>
-        </container>
-      </div>
-
-      <div class="v-container">
-        <container class="video-container">
-          <!-- 비디오 카드1 -->
-          <article class="video-card">
-            <a href="#" class="video-link">
-              <div class="thumbnail"></div>
-              <div class="details">
-                <div class="avatar-container"></div>
-                <div class="meta">
-                  <div class="meta-header">
-                    <h3 class="video-title">비디오 타이틀</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="channel-name">채널명</p>
-                  <p class="video-stats">조회수 • 일자</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 비디오 카드2 -->
-          <article class="video-card">
-            <a href="#" class="video-link">
-              <div class="thumbnail"></div>
-              <div class="details">
-                <div class="avatar-container"></div>
-                <div class="meta">
-                  <div class="meta-header">
-                    <h3 class="video-title">비디오 타이틀</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="channel-name">채널명</p>
-                  <p class="video-stats">조회수 • 일자</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 비디오 카드3 -->
-          <article class="video-card">
-            <a href="#" class="video-link">
-              <div class="thumbnail"></div>
-              <div class="details">
-                <div class="avatar-container"></div>
-                <div class="meta">
-                  <div class="meta-header">
-                    <h3 class="video-title">비디오 타이틀</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="channel-name">채널명</p>
-                  <p class="video-stats">조회수 • 일자</p>
-                </div>
-              </div>
-            </a>
-          </article>
-          <!-- 비디오 카드4 -->
-          <article class="video-card">
-            <a href="#" class="video-link">
-              <div class="thumbnail"></div>
-              <div class="details">
-                <div class="avatar-container"></div>
-                <div class="meta">
-                  <div class="meta-header">
-                    <h3 class="video-title">비디오 타이틀</h3>
-                    <button class="kebab-menu-btn">
-                      <i class="icon-ellipsis-vertical"></i>
-                    </button>
-                  </div>
-                  <p class="channel-name">채널명</p>
-                  <p class="video-stats">조회수 • 일자</p>
-                </div>
-              </div>
-            </a>
-          </article>
-        </container>
       <!-- 사이드바 -->
       <nav class="sidebar" aria-label="주요 메뉴">
         <ul class="sidebar-section">
@@ -490,6 +193,305 @@
         <button class="chip">감상한 동영상</button>
         <button class="chip">새로운 맞춤 동영상</button>
       </div>
+
+      <!-- 컨텐츠 영역 -->
+      <div class="v-container">
+        <div class="video-container">
+          <!-- 비디오 카드1 -->
+          <article class="video-card">
+            <a href="#" class="video-link">
+              <div class="thumbnail"></div>
+              <div class="details">
+                <div class="avatar-container"></div>
+                <div class="meta">
+                  <div class="meta-header">
+                    <h3 class="video-title">비디오 타이틀</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="channel-name">채널명</p>
+                  <p class="video-stats">조회수 • 일자</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 비디오 카드2 -->
+          <article class="video-card">
+            <a href="#" class="video-link">
+              <div class="thumbnail"></div>
+              <div class="details">
+                <div class="avatar-container"></div>
+                <div class="meta">
+                  <div class="meta-header">
+                    <h3 class="video-title">비디오 타이틀</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="channel-name">채널명</p>
+                  <p class="video-stats">조회수 • 일자</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 비디오 카드3 -->
+          <article class="video-card">
+            <a href="#" class="video-link">
+              <div class="thumbnail"></div>
+              <div class="details">
+                <div class="avatar-container"></div>
+                <div class="meta">
+                  <div class="meta-header">
+                    <h3 class="video-title">비디오 타이틀</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="channel-name">채널명</p>
+                  <p class="video-stats">조회수 • 일자</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 비디오 카드4 -->
+          <article class="video-card">
+            <a href="#" class="video-link">
+              <div class="thumbnail"></div>
+              <div class="details">
+                <div class="avatar-container"></div>
+                <div class="meta">
+                  <div class="meta-header">
+                    <h3 class="video-title">비디오 타이틀</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="channel-name">채널명</p>
+                  <p class="video-stats">조회수 • 일자</p>
+                </div>
+              </div>
+            </a>
+          </article>
+        </div>
+        <h2 class="shorts-logo">
+          <svg
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          > <title>YouTube Shorts</title>
+            <path
+              fill="currentColor"
+              d="m18.931 9.99-1.441-.601 1.717-.913a4.48 4.48 0 0 0 1.874-6.078 4.506 4.506 0 0 0-6.09-1.874L4.792 
+            5.929a4.504 4.504 0 0 0-2.402 4.193 4.521 4.521 0 0 0 2.666 3.904c.036.012 1.442.6 1.442.6l-1.706.901a4.51 
+            4.51 0 0 0-2.369 3.967A4.528 4.528 0 0 0 6.93 24c.725 0 1.437-.174 2.08-.508l10.21-5.406a4.494 4.494 0 0 0 
+            2.39-4.192 4.525 4.525 0 0 0-2.678-3.904ZM9.597 15.19V8.824l6.007 3.184z"
+            />
+          </svg>
+          <span class="shorts-text">Shorts</span>
+        </h2>
+        <div class="shorts-container">
+          <!-- 쇼츠 카드1 -->
+          <article class="shorts-card">
+            <a href="#" class="shorts-link">
+               <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/lPF6RwWyzTw/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLDRFfR5DbA0xTuwz0ixXEZT7-tMrw" alt="피자헛 치즈 크러스트 소송">
+              <div class="shorts-details">
+                <div class="s-meta">
+                  <div class="s-meta-header">
+                    <h3 class="shorts-title">피자헛 치즈 크러스트 소송</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="video-stats">조회수 154만회</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 쇼츠 카드2 -->
+          <article class="shorts-card">
+            <a href="#" class="shorts-link">
+              <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/1asKWWsJdKA/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLCuL7O1sYf10SBPWM2omUbTG2aI9g" alt="인도 음식을 먹은 유튜버의 최후">
+              <div class="shorts-details">
+                <div class="s-meta">
+                  <div class="s-meta-header">
+                    <h3 class="shorts-title">인도 음식을 먹은 유튜버의 최후</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="video-stats">조회수 306만회</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 쇼츠 카드3 -->
+          <article class="shorts-card">
+            <a href="#" class="shorts-link">
+              <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/CzWoRmk7HiE/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLBA5uOP3SOaFtP1rhGr_TjRs108Wg" alt="중국 공포의 공중다리 #여행">
+              <div class="shorts-details">
+                <div class="s-meta">
+                  <div class="s-meta-header">
+                    <h3 class="shorts-title">중국 공포의 공중다리 #여행</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="video-stats">조회수 150만회</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 쇼츠 카드4 -->
+          <article class="shorts-card">
+            <a href="#" class="shorts-link">
+              <img class="shorts-thumbnail"src="https://i.ytimg.com/vi/-3pMaq8Vka8/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLBVil2Tlj46Jw2_-oD1FrT34RFyQw" alt="일부러 검은색이 될 때까지 쓰는 거라는데?">
+              <div class="shorts-details">
+                <div class="s-meta">
+                  <div class="s-meta-header">
+                    <h3 class="shorts-title">일부러 검은색이 될 때까지 쓰는 거라는데?</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="video-stats">조회수 165만회</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 쇼츠 카드5 -->
+          <article class="shorts-card">
+            <a href="#" class="shorts-link">
+              <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/izWBMptqL68/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLC3j2sP2PKGrcmugOUo15YXHpKbuA" alt="골절된 말을 안락사 시키는 이유">
+              <div class="shorts-details">
+                <div class="s-meta">
+                  <div class="s-meta-header">
+                    <h3 class="shorts-title">골절된 말을 안락사 시키는 이유</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="video-stats">조회수 315만회</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 쇼츠 카드6 -->
+          <article class="shorts-card">
+            <a href="#" class="shorts-link">
+              <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/akdd0ny6i8w/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLDa1AXCKtH-iYio8Uio4Kyk8qMyHQ" alt="호수에 이게 대체 왜 있을까?">
+              <div class="shorts-details">
+                <div class="s-meta">
+                  <div class="s-meta-header">
+                    <h3 class="shorts-title">호수에 이게 대체 왜 있을까?</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="video-stats">조회수 7.1만회</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 쇼츠 카드7 -->
+          <article class="shorts-card">
+            <a href="#" class="shorts-link">
+              <img class="shorts-thumbnail" src="https://i.ytimg.com/vi/bxemLsZVlVE/oardefault.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLA3A6CXlVcy_HcARMNkuWb41P8PfQ" alt="낫토와 청국장의 차이">
+              <div class="shorts-title">
+                <div class="s-meta">
+                  <div class="s-meta-header">
+                    <h3 class="shorts-title">낫토와 청국장의 차이</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="video-stats">조회수 10만회</p>
+                </div>
+              </div>
+            </a>
+          </article>
+        </div>
+      </div>
+
+      <div class="v-container">
+        <div class="video-container">
+          <!-- 비디오 카드1 -->
+          <article class="video-card">
+            <a href="#" class="video-link">
+              <div class="thumbnail"></div>
+              <div class="details">
+                <div class="avatar-container"></div>
+                <div class="meta">
+                  <div class="meta-header">
+                    <h3 class="video-title">비디오 타이틀</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="channel-name">채널명</p>
+                  <p class="video-stats">조회수 • 일자</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 비디오 카드2 -->
+          <article class="video-card">
+            <a href="#" class="video-link">
+              <div class="thumbnail"></div>
+              <div class="details">
+                <div class="avatar-container"></div>
+                <div class="meta">
+                  <div class="meta-header">
+                    <h3 class="video-title">비디오 타이틀</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="channel-name">채널명</p>
+                  <p class="video-stats">조회수 • 일자</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 비디오 카드3 -->
+          <article class="video-card">
+            <a href="#" class="video-link">
+              <div class="thumbnail"></div>
+              <div class="details">
+                <div class="avatar-container"></div>
+                <div class="meta">
+                  <div class="meta-header">
+                    <h3 class="video-title">비디오 타이틀</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="channel-name">채널명</p>
+                  <p class="video-stats">조회수 • 일자</p>
+                </div>
+              </div>
+            </a>
+          </article>
+          <!-- 비디오 카드4 -->
+          <article class="video-card">
+            <a href="#" class="video-link">
+              <div class="thumbnail"></div>
+              <div class="details">
+                <div class="avatar-container"></div>
+                <div class="meta">
+                  <div class="meta-header">
+                    <h3 class="video-title">비디오 타이틀</h3>
+                    <button class="kebab-menu-btn">
+                      <i class="icon-ellipsis-vertical"></i>
+                    </button>
+                  </div>
+                  <p class="channel-name">채널명</p>
+                  <p class="video-stats">조회수 • 일자</p>
+                </div>
+              </div>
+            </a>
+          </article>
+        </div>
     </main>
 
     <script src="script.js"></script>

--- a/02_youtube/styles.css
+++ b/02_youtube/styles.css
@@ -273,7 +273,6 @@ body {
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: 16px;
   width: calc(100% - 240px);
-  box-sizing: border-box;
 }
 
 .video-card {


### PR DESCRIPTION
- 렌더링 과정에서 sidebar와 chips bar보다 컨텐츠 영역을 먼저 생성하면서 발생한 오류로 추정
- 고정된 sidebar와 미리 자리를 선점하고 있던 컨텐츠 영역의 충돌
- html 코드 위치 변경을 통해 해결(main태그 내의 sidebar, chips <--> contents)
- css v-container내의 중복 요소 제거 (border-box)

**Before**
![image](https://github.com/user-attachments/assets/a69560ca-7ed5-44b6-866e-250e676c7802)

**After**
![image](https://github.com/user-attachments/assets/20f87377-b997-4f18-915d-4e15c67ab452)

