### PR TITLE
메인 오른쪽 사이드바 CSS 수정

### DIFF
--- a/03_instagram/css/feed.css
+++ b/03_instagram/css/feed.css
@@ -163,6 +163,7 @@ body {
   font-weight: bold;
 }
 .suggest-info .note {
+  display: block;
   font-size: 12px;
   color: #8e8e8e;
 }


### PR DESCRIPTION
# 설명
메인 오른쪽 사이드바 유저명과 상세정보가 같은 줄에 있어 가독성이 떨어지는 문제 해결

#80 

# 체크리스트:

- [x] 유저명과 상세정보 줄 구분


## 스크린샷 첨부 (선택)
![image](https://github.com/user-attachments/assets/c23b3792-1e1d-440b-ac36-5fe5be1b5178)
